### PR TITLE
Embed high level bufr interface from ecCodes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include *.bufr
 include *.yml
 include LICENSE
 include Makefile
+include mypi.ini
 recursive-include tests *.bufr
 recursive-include tests *.py
 recursive-include tests *.yml

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ include *.bufr
 include *.yml
 include LICENSE
 include Makefile
-include mypi.ini
+include mypy.ini
 recursive-include tests *.bufr
 recursive-include tests *.py
 recursive-include tests *.yml

--- a/README.rst
+++ b/README.rst
@@ -130,6 +130,9 @@ Main contributors:
 - `Sandor Kertesz <https://github.com/sandorkertesz>`_ - `ECMWF <https://ecmwf.int>`_
 - `Iain Russell <https://github.com/iainrussell>`_ - ECMWF
 
+Also:
+- Daniel Lee - DWD, who contributed the code in the high_level_bufr directory, originally part of eccodes-python
+
 See also the list of `contributors <https://github.com/ecmwf/pdbufr/contributors>`_ who participated in this project.
 
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+[mypy-pdbufr.high_level_bufr.*]
+ignore_errors = True

--- a/pdbufr/bufr_read.py
+++ b/pdbufr/bufr_read.py
@@ -23,8 +23,8 @@ import typing as T
 import eccodes  # type: ignore
 import pandas as pd  # type: ignore
 
-from .high_level_bufr.bufr import BufrFile
 from . import bufr_structure
+from .high_level_bufr.bufr import BufrFile
 
 
 def read_bufr(

--- a/pdbufr/bufr_read.py
+++ b/pdbufr/bufr_read.py
@@ -23,6 +23,7 @@ import typing as T
 import eccodes  # type: ignore
 import pandas as pd  # type: ignore
 
+from .high_level_bufr.bufr import BufrFile
 from . import bufr_structure
 
 
@@ -41,7 +42,7 @@ def read_bufr(
     :param required_columns: The list BUFR keys that are required for all observations.
         ``True`` means all ``columns`` are required
     """
-    with eccodes.BufrFile(path) as bufr_file:
+    with BufrFile(path) as bufr_file:
         observations = bufr_structure.stream_bufr(
             bufr_file, columns, filters, required_columns
         )

--- a/pdbufr/bufr_read.py
+++ b/pdbufr/bufr_read.py
@@ -24,7 +24,7 @@ import eccodes  # type: ignore
 import pandas as pd  # type: ignore
 
 from . import bufr_structure
-from .high_level_bufr.bufr import BufrFile
+from .high_level_bufr.bufr import BufrFile  # type: ignore
 
 
 def read_bufr(

--- a/pdbufr/bufr_read.py
+++ b/pdbufr/bufr_read.py
@@ -24,7 +24,7 @@ import eccodes  # type: ignore
 import pandas as pd  # type: ignore
 
 from . import bufr_structure
-from .high_level_bufr.bufr import BufrFile  # type: ignore
+from .high_level_bufr.bufr import BufrFile
 
 
 def read_bufr(
@@ -42,7 +42,7 @@ def read_bufr(
     :param required_columns: The list BUFR keys that are required for all observations.
         ``True`` means all ``columns`` are required
     """
-    with BufrFile(path) as bufr_file:
+    with BufrFile(path) as bufr_file:  # type: ignore
         observations = bufr_structure.stream_bufr(
             bufr_file, columns, filters, required_columns
         )

--- a/pdbufr/bufr_structure.py
+++ b/pdbufr/bufr_structure.py
@@ -62,8 +62,7 @@ def message_structure(message: T.Mapping[str, T.Any]) -> T.Iterator[T.Tuple[int,
 
 
 def filter_keys(
-    message: T.Mapping[str, T.Any],
-    include: T.Container[str] = (),
+    message: T.Mapping[str, T.Any], include: T.Container[str] = (),
 ) -> T.Iterator[BufrKey]:
     for level, key in message_structure(message):
         bufr_key = BufrKey.from_level_key(level, key)
@@ -301,10 +300,7 @@ def stream_bufr(
         else:
             observation = {}
         for observation in extract_observations(
-            message,
-            filtered_keys,
-            value_filters,
-            observation,
+            message, filtered_keys, value_filters, observation,
         ):
             augmented_observation = add_computed_keys(observation, included_keys)
             data = {k: v for k, v in augmented_observation.items() if k in columns}

--- a/pdbufr/bufr_structure.py
+++ b/pdbufr/bufr_structure.py
@@ -62,7 +62,8 @@ def message_structure(message: T.Mapping[str, T.Any]) -> T.Iterator[T.Tuple[int,
 
 
 def filter_keys(
-    message: T.Mapping[str, T.Any], include: T.Container[str] = (),
+    message: T.Mapping[str, T.Any],
+    include: T.Container[str] = (),
 ) -> T.Iterator[BufrKey]:
     for level, key in message_structure(message):
         bufr_key = BufrKey.from_level_key(level, key)
@@ -300,7 +301,10 @@ def stream_bufr(
         else:
             observation = {}
         for observation in extract_observations(
-            message, filtered_keys, value_filters, observation,
+            message,
+            filtered_keys,
+            value_filters,
+            observation,
         ):
             augmented_observation = add_computed_keys(observation, included_keys)
             data = {k: v for k, v in augmented_observation.items() if k in columns}

--- a/pdbufr/high_level_bufr/bufr.py
+++ b/pdbufr/high_level_bufr/bufr.py
@@ -12,8 +12,9 @@ Author: Daniel Lee, DWD, 2016
 """
 
 import eccodes
-from .codesmessage import CodesMessage
+
 from .codesfile import CodesFile
+from .codesmessage import CodesMessage
 
 
 class BufrMessage(CodesMessage):

--- a/pdbufr/high_level_bufr/bufr.py
+++ b/pdbufr/high_level_bufr/bufr.py
@@ -1,0 +1,100 @@
+"""
+Note: the files in this directory have been copied from eccodes-python and
+retain their original notice.
+
+Classes for handling BUFR with a high level interface.
+
+``BufrFiles`` can be treated mostly as regular files and used as context
+managers, as can ``BufrMessages``. Each of these classes destructs itself and
+any child instances appropriately.
+
+Author: Daniel Lee, DWD, 2016
+"""
+
+import eccodes
+from .codesmessage import CodesMessage
+from .codesfile import CodesFile
+
+
+class BufrMessage(CodesMessage):
+
+    __doc__ = "\n".join(CodesMessage.__doc__.splitlines()[4:]).format(
+        prod_type="BUFR", classname="BufrMessage", parent="BufrFile", alias="bufr"
+    )
+
+    product_kind = eccodes.CODES_PRODUCT_BUFR
+
+    # Arguments included explicitly to support introspection
+    # TODO: Can we get this to work with an index?
+    def __init__(self, codes_file=None, clone=None, sample=None, headers_only=False):
+        """
+        Open a message and inform the GRIB file that it's been incremented.
+
+        The message is taken from ``codes_file``, cloned from ``clone`` or
+        ``sample``, or taken from ``index``, in that order of precedence.
+        """
+        super(self.__class__, self).__init__(codes_file, clone, sample, headers_only)
+        # self._unpacked = False
+
+    # def get(self, key, ktype=None):
+    #    """Return requested value, unpacking data values if necessary."""
+    #    # TODO: Only do this if accessing arrays that need unpacking
+    #    if not self._unpacked:
+    #        self.unpacked = True
+    #    return super(self.__class__, self).get(key, ktype)
+
+    # def missing(self, key):
+    #    """
+    #    Report if key is missing.#
+    #
+    #    Overloaded due to confusing behaviour in ``codes_is_missing`` (SUP-1874).
+    #    """
+    #    return not bool(eccodes.codes_is_defined(self.codes_id, key))
+
+    def unpack(self):
+        """Decode data section"""
+        eccodes.codes_set(self.codes_id, "unpack", 1)
+
+    def pack(self):
+        """Encode data section"""
+        eccodes.codes_set(self.codes_id, "pack", 1)
+
+    def keys(self, namespace=None):
+        # self.unpack()
+        # return super(self.__class__, self).keys(namespace)
+        iterator = eccodes.codes_bufr_keys_iterator_new(self.codes_id)
+        keys = []
+        while eccodes.codes_bufr_keys_iterator_next(iterator):
+            key = eccodes.codes_bufr_keys_iterator_get_name(iterator)
+            keys.append(key)
+        eccodes.codes_bufr_keys_iterator_delete(iterator)
+        return keys
+
+    # @property
+    # def unpacked(self):
+    #    return self._unpacked
+
+    # @unpacked.setter
+    # def unpacked(self, val):
+    #    eccodes.codes_set(self.codes_id, "unpack", val)
+    #    self._unpacked = val
+
+    # def __setitem__(self, key, value):
+    #    """Set item and pack BUFR."""
+    #    if not self._unpacked:
+    #        self.unpacked = True
+    #    super(self.__class__, self).__setitem__(key, value)
+    #    eccodes.codes_set(self.codes_id, "pack", True)
+
+    def copy_data(self, destMsg):
+        """Copy data values from this message to another message"""
+        return eccodes.codes_bufr_copy_data(self.codes_id, destMsg.codes_id)
+
+
+class BufrFile(CodesFile):
+
+    __doc__ = "\n".join(CodesFile.__doc__.splitlines()[4:]).format(
+        prod_type="BUFR", classname="BufrFile", alias="bufr"
+    )
+
+    MessageClass = BufrMessage

--- a/pdbufr/high_level_bufr/codesfile.py
+++ b/pdbufr/high_level_bufr/codesfile.py
@@ -8,8 +8,9 @@ closes itself and its messages when it is no longer needed.
 Author: Daniel Lee, DWD, 2016
 """
 
-import eccodes
 import io
+
+import eccodes
 
 
 class CodesFile(io.FileIO):

--- a/pdbufr/high_level_bufr/codesfile.py
+++ b/pdbufr/high_level_bufr/codesfile.py
@@ -1,0 +1,80 @@
+"""
+Note: the files in this directory have been copied from eccodes-python and
+retain their original notice.
+
+``CodesFile`` class that implements a file that is readable by ecCodes and
+closes itself and its messages when it is no longer needed.
+
+Author: Daniel Lee, DWD, 2016
+"""
+
+import eccodes
+import io
+
+
+class CodesFile(io.FileIO):
+
+    """
+    An abstract class to specify and/or implement common behaviour that files
+    read by ecCodes should implement.
+
+    A {prod_type} file handle meant for use in a context manager.
+
+    Individual messages can be accessed using the ``next`` method. Of course,
+    it is also possible to iterate over each message in the file::
+
+        >>> with {classname}(filename) as {alias}:
+        ...     # Print number of messages in file
+        ...     len({alias})
+        ...     # Open all messages in file
+        ...     for msg in {alias}:
+        ...         print(msg[key_name])
+        ...     len({alias}.open_messages)
+        >>> # When the file is closed, any open messages are closed
+        >>> len({alias}.open_messages)
+    """
+
+    #: Type of messages belonging to this file
+    MessageClass = None
+
+    def __init__(self, filename, mode="rb"):
+        """Open file and receive codes file handle."""
+        #: File handle for working with actual file on disc
+        #: The class holds the file it works with because ecCodes'
+        # typechecking does not allow using inherited classes.
+        self.file_handle = open(filename, mode)
+        #: Number of message in file currently being read
+        self.message = 0
+        #: Open messages
+        self.open_messages = []
+        self.name = filename
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        """Close all open messages, release file handle and close file."""
+        while self.open_messages:
+            # Note: if the message was manually closed, this has no effect
+            self.open_messages.pop().close()
+        self.file_handle.close()
+
+    def __len__(self):
+        """Return total number of messages in file."""
+        return eccodes.codes_count_in_file(self.file_handle)
+
+    def __enter__(self):
+        return self
+
+    def close(self):
+        """Possibility to manually close file."""
+        self.__exit__(None, None, None)
+
+    def __iter__(self):
+        return self
+
+    def next(self):
+        try:
+            return self.MessageClass(self)
+        except IOError:
+            raise StopIteration()
+
+    def __next__(self):
+        return self.next()

--- a/pdbufr/high_level_bufr/codesmessage.py
+++ b/pdbufr/high_level_bufr/codesmessage.py
@@ -1,0 +1,200 @@
+"""
+Note: the files in this directory have been copied from eccodes-python and
+retain their original notice.
+
+``CodesMessage`` class that implements a message readable by ecCodes that
+allows access to the message's key-value pairs in a dictionary-like manner
+and closes the message when it is no longer needed, coordinating this with
+its host file.
+
+Author: Daniel Lee, DWD, 2016
+"""
+
+import eccodes
+
+
+class CodesMessage(object):
+
+    """
+    An abstract class to specify and/or implement common behaviour that
+    messages read by ecCodes should implement.
+
+    A {prod_type} message.
+
+    Each ``{classname}`` is stored as a key/value pair in a dictionary-like
+    structure. It can be used in a context manager or by itself. When the
+    ``{parent}`` it belongs to is closed, the ``{parent}`` closes any open
+    ``{classname}``s that belong to it. If a ``{classname}`` is closed before
+    its ``{parent}`` is closed, it informs the ``{parent}`` of its closure.
+
+    Scalar and vector values are set appropriately through the same method.
+
+    ``{classname}``s can be instantiated from a ``{parent}``, cloned from
+    other ``{classname}``s or taken from samples. Iterating over the members
+    of a ``{parent}`` extracts the ``{classname}``s it contains until the
+    ``{parent}`` is exhausted.
+
+    Usage::
+
+        >>> with {parent}(filename) as {alias}:
+        ...     # Access a key from each message
+        ...     for msg in {alias}:
+        ...         print(msg[key_name])
+        ...     # Report number of keys in message
+        ...     len(msg)
+        ...     # Report message size in bytes
+        ...     msg.size
+        ...     # Report keys in message
+        ...     msg.keys()
+        ...     # Set scalar value
+        ...     msg[scalar_key] = 5
+        ...     # Check key's value
+        ...     msg[scalar_key]
+        ...     msg[key_name]
+        ...     # Array values are set transparently
+        ...     msg[array_key] = [1, 2, 3]
+        ...     # Messages can be written to file
+        ...     with open(testfile, "w") as test:
+        ...         msg.write(test)
+        ...     # Messages can be cloned from other messages
+        ...     msg2 = {classname}(clone=msg)
+        ...     # If desired, messages can be closed manually or used in with
+        ...     msg.close()
+    """
+
+    #: ecCodes enum-like PRODUCT constant
+    product_kind = None
+
+    def __init__(
+        self,
+        codes_file=None,
+        clone=None,
+        sample=None,
+        headers_only=False,
+        other_args_found=False,
+    ):
+        """
+        Open a message and inform the host file that it's been incremented.
+
+        If ``codes_file`` is not supplied, the message is cloned from
+        ``CodesMessage`` ``clone``. If neither is supplied,
+        the ``CodesMessage`` is cloned from ``sample``.
+
+        :param codes_file: A file readable for ecCodes
+        :param clone: A valid ``CodesMessage``
+        :param sample: A valid sample path to create ``CodesMessage`` from
+        """
+        if (
+            not other_args_found
+            and codes_file is None
+            and clone is None
+            and sample is None
+        ):
+            raise RuntimeError("CodesMessage initialization parameters not " "present.")
+        #: Unique ID, for ecCodes interface
+        self.codes_id = None
+        #: File containing message
+        self.codes_file = None
+        if codes_file is not None:
+            self.codes_id = eccodes.codes_new_from_file(
+                codes_file.file_handle, self.product_kind, headers_only
+            )
+            if self.codes_id is None:
+                raise IOError("CodesFile %s is exhausted" % codes_file.name)
+            self.codes_file = codes_file
+            self.codes_file.message += 1
+            self.codes_file.open_messages.append(self)
+        elif clone is not None:
+            self.codes_id = eccodes.codes_clone(clone.codes_id)
+        elif sample is not None:
+            self.codes_id = eccodes.codes_new_from_samples(sample, self.product_kind)
+
+    def write(self, outfile=None):
+        """Write message to file."""
+        if not outfile:
+            # This is a hack because the API does not accept inheritance
+            outfile = self.codes_file.file_handle
+        eccodes.codes_write(self.codes_id, outfile)
+
+    def __setitem__(self, key, value):
+        """
+        Set value associated with key.
+
+        Iterables and scalars are handled intelligently.
+        """
+        if isinstance(key, str):
+            if hasattr(value, "__iter__") and not isinstance(value, str):
+                eccodes.codes_set_array(self.codes_id, key, value)
+            else:
+                eccodes.codes_set(self.codes_id, key, value)
+        else:
+            if len(key) != len(value):
+                raise ValueError("Key array must have same size as value array")
+            eccodes.codes_set_key_vals(
+                self.codes_id,
+                ",".join([str(key[i]) + "=" + str(value[i]) for i in range(len(key))]),
+            )
+
+    def keys(self, namespace=None):
+        """Get available keys in message."""
+        iterator = eccodes.codes_keys_iterator_new(self.codes_id, namespace=namespace)
+        keys = []
+        while eccodes.codes_keys_iterator_next(iterator):
+            key = eccodes.codes_keys_iterator_get_name(iterator)
+            keys.append(key)
+        eccodes.codes_keys_iterator_delete(iterator)
+        return keys
+
+    def size(self):
+        """Return size of message in bytes."""
+        return eccodes.codes_get_message_size(self.codes_id)
+
+    def dump(self):
+        """Dump message's binary content."""
+        return eccodes.codes_get_message(self.codes_id)
+
+    def get(self, key, ktype=None):
+        """Get value of a given key as its native or specified type."""
+        # if self.missing(key):
+        #    raise KeyError("Value of key %s is MISSING." % key)
+        if eccodes.codes_get_size(self.codes_id, key) > 1:
+            ret = eccodes.codes_get_array(self.codes_id, key, ktype)
+        else:
+            ret = eccodes.codes_get(self.codes_id, key, ktype)
+        return ret
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Release message handle and inform host file of release."""
+        if self.codes_id != -1:
+            eccodes.codes_release(self.codes_id)
+            self.codes_id = -1
+
+    def __enter__(self):
+        return self
+
+    def close(self):
+        """Possibility to manually close message."""
+        self.__exit__(None, None, None)
+
+    def __contains__(self, key):
+        """Check whether a key is present in message."""
+        return key in self.keys()
+
+    def __len__(self):
+        """Return key count."""
+        return len(self.keys())
+
+    def __getitem__(self, key):
+        """Return value associated with key as its native type."""
+        return self.get(key)
+
+    def __iter__(self):
+        return iter(self.keys())
+
+    # Not yet implemented
+    # def itervalues(self):
+    #    return self.values()
+
+    def items(self):
+        """Return list of tuples of all key/value pairs."""
+        return [(key, self[key]) for key in self.keys()]

--- a/tests/test_20_bufr_structure.py
+++ b/tests/test_20_bufr_structure.py
@@ -365,7 +365,12 @@ def test_stream_bufr() -> None:
 
     expected_2 = [{"WMO_station_id": 1128}]
 
-    res = list(bufr_structure.stream_bufr(messages, ["WMO_station_id"],))
+    res = list(
+        bufr_structure.stream_bufr(
+            messages,
+            ["WMO_station_id"],
+        )
+    )
 
     assert len(res) == 1
     assert res == expected_2

--- a/tests/test_20_bufr_structure.py
+++ b/tests/test_20_bufr_structure.py
@@ -365,12 +365,7 @@ def test_stream_bufr() -> None:
 
     expected_2 = [{"WMO_station_id": 1128}]
 
-    res = list(
-        bufr_structure.stream_bufr(
-            messages,
-            ["WMO_station_id"],
-        )
-    )
+    res = list(bufr_structure.stream_bufr(messages, ["WMO_station_id"],))
 
     assert len(res) == 1
     assert res == expected_2


### PR DESCRIPTION
ecCodes contains an experimental high-level API that was never really documented or advertised, and will likely be removed. However, pdbufr uses some of its functionality and so this PR is to embed the relevant portions of that code directly into pdbufr, at least for now. As the code was originally a contribution, I have retained the original headers on the code, with an additional note to say that it came from ecCodes.

I will merge this by the end of today unless there are objections.

For information: @b8raoult , @shahramn , @StephanSiemen , @sandorkertesz 