### PR TITLE
Feature/performance

### DIFF
--- a/pdbufr/bufr_structure.py
+++ b/pdbufr/bufr_structure.py
@@ -89,7 +89,7 @@ class UncompressedBufrKey:
 IS_KEY_COORD = {"subsetNumber": True, "operator": False}
 
 
-def wrap_message(m):
+def wrap_message(m: T.Any) -> T.Any:
     if isinstance(m, BufrMessage):
         return m
     else:
@@ -108,20 +108,20 @@ class MessageWrapper:
     def __exit__(self, *args) -> None:  # type: ignore
         pass
 
-    def __iter__(self):
+    def __iter__(self):  # type: ignore
         return self.d.__iter__()
 
-    def code(self, key, name=None):
+    def code(self, key, name=None):  # type: ignore
         return self.d[key + "->code"]
 
-    def __getattr__(self, fname):
-        def call_func(*args, **kwargs):
+    def __getattr__(self, fname):  # type: ignore
+        def call_func(*args, **kwargs):  # type: ignore
             return getattr(self.d, fname, *args, **kwargs)
 
         return call_func
 
 
-def message_structure(message: T.Mapping[str, T.Any]) -> T.Iterator[T.Tuple[int, str]]:
+def message_structure(message: T.Any) -> T.Iterator[T.Tuple[int, str]]:
     level = 0
     coords: T.Dict[str, int] = collections.OrderedDict()
 

--- a/pdbufr/bufr_structure.py
+++ b/pdbufr/bufr_structure.py
@@ -8,7 +8,6 @@
 
 import collections
 import datetime
-import re
 import typing as T
 
 import attr
@@ -90,20 +89,56 @@ class UncompressedBufrKey:
 IS_KEY_COORD = {"subsetNumber": True, "operator": False}
 
 
+def wrap_message(m):
+    if isinstance(m, BufrMessage):
+        return m
+    else:
+        return MessageWrapper(m)
+
+
+class MessageWrapper:
+    """Makes it possible to use context manager and code methods for all types of messages."""
+
+    def __init__(self, d: T.Any):
+        self.d = d
+
+    def __enter__(self) -> T.Any:
+        return self.d
+
+    def __exit__(self, *args) -> None:  # type: ignore
+        pass
+
+    def __iter__(self):
+        return self.d.__iter__()
+
+    def code(self, key, name=None):
+        return self.d[key + "->code"]
+
+    def __getattr__(self, fname):
+        def call_func(*args, **kwargs):
+            return getattr(self.d, fname, *args, **kwargs)
+
+        return call_func
+
+
 def message_structure(message: T.Mapping[str, T.Any]) -> T.Iterator[T.Tuple[int, str]]:
     level = 0
     coords: T.Dict[str, int] = collections.OrderedDict()
+
+    message = wrap_message(message)
+
     for key in message:
         name = key.rpartition("#")[2]
-
         if name in IS_KEY_COORD:
             is_coord = IS_KEY_COORD[name]
         else:
-            try:
-                code = message[key + "->code"]
-                is_coord = int(code[:3]) < 10
-            except KeyError:
-                is_coord = False
+            is_coord = name in coords
+            if not is_coord:
+                try:
+                    code = message.code(key, name)
+                    is_coord = int(code[:3]) < 10
+                except KeyError:
+                    is_coord = False
 
         while is_coord and name in coords:
             _, level = coords.popitem()  # OrderedDict.popitem uses LIFO order
@@ -551,23 +586,6 @@ def test_computed_keys(
     return True
 
 
-class CMWrapper:
-    """Makes it possible to use context manager both with BufrMessage and dict type of messages"""
-
-    def __init__(self, d: T.Any):
-        self.d = d
-
-    def __enter__(self) -> T.Any:
-        if isinstance(self.d, BufrMessage):
-            return self.d.__enter__()  # type: ignore
-        else:
-            return self.d
-
-    def __exit__(self, *args) -> None:  # type: ignore
-        if isinstance(self.d, BufrMessage):
-            self.d.__exit__(*args)  # type: ignore
-
-
 def stream_bufr(
     bufr_file: T.Iterable[T.MutableMapping[str, T.Any]],
     columns: T.Union[T.Sequence[str], str],
@@ -618,7 +636,7 @@ def stream_bufr(
     for count, msg in enumerate(bufr_file, 1):
         # we use a context manager to automatically delete the handle of the BufrMessage.
         # We have to use a wrapper object here because a message can also be a dict
-        with CMWrapper(msg) as message:
+        with wrap_message(msg) as message:
             if "count" in value_filters and not value_filters["count"].match(count):
                 continue
 
@@ -717,7 +735,7 @@ def stream_bufr_flat(
     for count, msg in enumerate(bufr_file, 1):
         # we use a context manager to automatically delete the handle of the BufrMessage.
         # We have to use a wrapper object here because a message can also be a dict
-        with CMWrapper(msg) as message:
+        with wrap_message(msg) as message:
             # count filter
             if count_filter is not None and not count_filter.match(count):
                 continue

--- a/pdbufr/high_level_bufr/bufr.py
+++ b/pdbufr/high_level_bufr/bufr.py
@@ -36,6 +36,8 @@ class BufrMessage(CodesMessage):
         super(self.__class__, self).__init__(codes_file, clone, sample, headers_only)
         # self._unpacked = False
 
+        self._is_coord_cache = dict()
+
     # def get(self, key, ktype=None):
     #    """Return requested value, unpacking data values if necessary."""
     #    # TODO: Only do this if accessing arrays that need unpacking
@@ -89,6 +91,31 @@ class BufrMessage(CodesMessage):
     def copy_data(self, destMsg):
         """Copy data values from this message to another message"""
         return eccodes.codes_bufr_copy_data(self.codes_id, destMsg.codes_id)
+
+    def is_coord(self, key, name=None):
+        if name is None:
+            name = key
+
+        c = self._is_coord_cache.get(name, None)
+        if c is None:
+            try:
+                c = self._get(name + "->code", int)
+                try:
+                    c = self.code_is_coord(c)
+                    self._is_coord_cache[name] = c
+                    return c
+                except:
+                    return False
+            except:
+                return False
+        return c
+
+    @staticmethod
+    def code_is_coord(code):
+        try:
+            return code <= 9999
+        except:
+            return int(code[:3]) < 10
 
 
 class BufrFile(CodesFile):

--- a/pdbufr/high_level_bufr/bufr.py
+++ b/pdbufr/high_level_bufr/bufr.py
@@ -111,7 +111,7 @@ class BufrMessage(CodesMessage):
         return c
 
     @staticmethod
-    def code_is_coord(code):
+    def code_is_coord(code) -> bool:
         try:
             return code <= 9999
         except:

--- a/pdbufr/high_level_bufr/codesmessage.py
+++ b/pdbufr/high_level_bufr/codesmessage.py
@@ -120,6 +120,8 @@ class CodesMessage(object):
         elif sample is not None:
             self.codes_id = eccodes.codes_new_from_samples(sample, self.product_kind)
 
+        self._codes = dict()
+
     def write(self, outfile=None):
         """Write message to file."""
         if not outfile:
@@ -208,3 +210,16 @@ class CodesMessage(object):
     def items(self):
         """Return list of tuples of all key/value pairs."""
         return [(key, self[key]) for key in self.keys()]
+
+    def code(self, key, name=None):
+        """Returns the BUFR descriptor, i.e. the code in the ecCodes terminology, of
+        the given key."""
+        if name is not None:
+            key = name
+        c = self._codes.get(key, None)
+        if c is None:
+            c_key = name + "->code"
+            with raise_keyerror(c_key):
+                c = eccodes.codes_get(self.codes_id, c_key, str)
+                self._codes[key] = c
+        return c

--- a/pdbufr/high_level_bufr/codesmessage.py
+++ b/pdbufr/high_level_bufr/codesmessage.py
@@ -120,8 +120,6 @@ class CodesMessage(object):
         elif sample is not None:
             self.codes_id = eccodes.codes_new_from_samples(sample, self.product_kind)
 
-        self._codes = dict()
-
     def write(self, outfile=None):
         """Write message to file."""
         if not outfile:
@@ -168,12 +166,21 @@ class CodesMessage(object):
 
     def get(self, key, ktype=None):
         """Get value of a given key as its native or specified type."""
+        # if key.endswith("->code"):
+        #     key = key.rpartition("->")[0]
+        #     name = key.rpartition("#")[2]
+        #     # print(name)
+        #     return self.code(key, name)
+
         with raise_keyerror(key):
             if eccodes.codes_get_size(self.codes_id, key) > 1:
                 ret = eccodes.codes_get_array(self.codes_id, key, ktype)
             else:
                 ret = eccodes.codes_get(self.codes_id, key, ktype)
             return ret
+
+    def _get(self, key, ktype=None):
+        return eccodes.codes_get(self.codes_id, key, ktype)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Release message handle and inform host file of release."""
@@ -210,16 +217,3 @@ class CodesMessage(object):
     def items(self):
         """Return list of tuples of all key/value pairs."""
         return [(key, self[key]) for key in self.keys()]
-
-    def code(self, key, name=None):
-        """Returns the BUFR descriptor, i.e. the code in the ecCodes terminology, of
-        the given key."""
-        if name is not None:
-            key = name
-        c = self._codes.get(key, None)
-        if c is None:
-            c_key = name + "->code"
-            with raise_keyerror(c_key):
-                c = eccodes.codes_get(self.codes_id, c_key, str)
-                self._codes[key] = c
-        return c

--- a/tests/test_20_bufr_structure.py
+++ b/tests/test_20_bufr_structure.py
@@ -420,3 +420,24 @@ def test_stream_bufr() -> None:
 
     assert len(res) == 1
     assert res == expected_2
+
+
+def test_code_is_coord() -> None:
+    """Ensures that the different ways of identifying a coordinate key from
+    the BUFR descriptor/code agree"""
+
+    from pdbufr.high_level_bufr.bufr import BufrMessage
+
+    data = {
+        "000300": True,
+        "010000": False,
+        "009999": True,
+        "010999": False,
+        "100000": False,
+        "201001": False,
+        "301001": False,
+    }
+
+    for k, v in data.items():
+        assert BufrMessage.code_is_coord(k) == v
+        assert BufrMessage.code_is_coord(int(k)) == v


### PR DESCRIPTION
Fixes #53 

The problem in #53 was caused by calling the following code too many times to determine whether  a BUFR key is a coordinate:

```
code = eccodes.codes_get(key + "->code")
try:
    is_coord = code[:3] < 10
```

This PR improves the performance by caching the `is_coord` values within a given message and providing access to them via the newly added `BufrMessage.is_coord()` method. To make it work for messages defined as a mapping (e.g. dict) the message wrapper had to be modified. Please note that the coordinate test in the code snippet above was also optimised and  implemented roughly like this:

```
code = self._get(name + "->code", int)
is_coord = code <= 9999
```

The results are encouraging. For the full BUFR file from #53 this code:

```
import pdbufr

f = "i0tp_07062020_00.buf"
df = pdbufr.read_bufr(f,
    columns=("year",'month', "hour", "minute","latitude", "longitude", "atmosphericPathDelayInSatelliteSignal"),
                      filters={"stationOrSiteName": 'S3AG-EUME'},
    )
print(len(df))
```
runs in 8 min 24 sec on my MacBook.

As a reference, iterating through the messages with eccodes and unpacking each with the code below takes 7:26.

```
import eccodes

f = open("i0tp_07062020_00.buf", "rb")
    
while 1:
    bufr = eccodes.codes_bufr_new_from_file(f)
    if bufr is None:
        break
 
    eccodes.codes_set(bufr, "unpack", 1)
    eccodes.codes_release(bufr)
 
f.close()
```