### PR TITLE
Simplify code for checking if a key is a coordinate

### DIFF
--- a/pdbufr/bufr_structure.py
+++ b/pdbufr/bufr_structure.py
@@ -14,7 +14,7 @@ import attr
 import eccodes  # type: ignore
 import numpy as np
 
-from pdbufr.high_level_bufr.bufr import BufrMessage
+from pdbufr.high_level_bufr.bufr import bufr_code_is_coord
 
 from . import bufr_filters
 
@@ -89,34 +89,55 @@ class UncompressedBufrKey:
 IS_KEY_COORD = {"subsetNumber": True, "operator": False}
 
 
-def wrap_message(m: T.Any) -> T.Any:
-    if isinstance(m, BufrMessage):
-        return m
-    else:
-        return MessageWrapper(m)
-
-
 class MessageWrapper:
-    """Makes it possible to use context manager and is_coord methods for all
+    """Makes it possible to use context manager and is_coord method for all
     types of messages."""
+
+    WRAP: T.Dict[T.Any, T.Any] = {}
 
     def __init__(self, d: T.Any):
         self.d = d
+        self.wrap_enter = not hasattr(d, "__enter__")
+        self.wrap_exit = not hasattr(d, "__exit__")
+        self.wrap_is_coord = not hasattr(d, "is_coord")
+
+    @staticmethod
+    def wrap(m: T.Any) -> T.Any:
+        t = type(m)
+        w = MessageWrapper.WRAP.get(t, None)
+        if w is None:
+            w = not all(
+                [
+                    hasattr(m, "__enter__"),
+                    hasattr(m, "__exit__"),
+                    hasattr(m, "is_coord"),
+                ]
+            )
+
+            MessageWrapper.WRAP[t] = w
+
+        if not w:
+            return m
+        else:
+            return MessageWrapper(m)
 
     def __enter__(self) -> T.Any:
-        return self.d
+        if self.wrap_enter:
+            return self.d
+        else:
+            return self.d.__enter__()
 
     def __exit__(self, *args) -> None:  # type: ignore
-        pass
+        if self.wrap_exit:
+            pass
+        else:
+            self.d.__exit__(*args)
 
     def __iter__(self):  # type: ignore
         return self.d.__iter__()
 
-    def is_coord(self, key, name=None):  # type: ignore
-        try:
-            return BufrMessage.code_is_coord(self.d[key + "->code"])
-        except Exception:
-            return False
+    def __getitem__(self, key: str) -> T.Any:
+        return self.d[key]
 
     def __getattr__(self, fname):  # type: ignore
         def call_func(*args, **kwargs):  # type: ignore
@@ -124,19 +145,51 @@ class MessageWrapper:
 
         return call_func
 
+    def is_coord(self, key: str) -> bool:
+        if self.wrap_is_coord:
+            try:
+                return bufr_code_is_coord(self.d[key + "->code"])
+            except Exception:
+                return False
+        else:
+            return self.d.is_coord(key)  # type: ignore
+
+
+class IsCoordCache:
+    """Caches if a BUFR key is a coordinate descriptor"""
+
+    def __init__(self, message: T.Any) -> None:
+        self.message = message
+        self.cache: T.Dict[str, bool] = {}
+
+    def check(self, key: str, name: str) -> bool:
+        c = self.cache.get(name, None)
+        if c is None:
+            if name in IS_KEY_COORD:
+                c = IS_KEY_COORD[name]
+                self.cache[name] = c
+                return c
+            else:
+                try:
+                    c = self.message.is_coord(key)
+                    self.cache[name] = c
+                    return c
+                except:
+                    return False
+        return c
+
 
 def message_structure(message: T.Any) -> T.Iterator[T.Tuple[int, str]]:
     level = 0
     coords: T.Dict[str, int] = collections.OrderedDict()
 
-    message = wrap_message(message)
+    message = MessageWrapper.wrap(message)
+    is_coord_cache = IsCoordCache(message)
+
     for key in message:
         name = key.rpartition("#")[2]
-        if name in IS_KEY_COORD:
-            is_coord = IS_KEY_COORD[name]
-        else:
-            is_coord = message.is_coord(key, name)
 
+        is_coord = is_coord_cache.check(key, name)
         while is_coord and name in coords:
             _, level = coords.popitem()  # OrderedDict.popitem uses LIFO order
 
@@ -633,7 +686,7 @@ def stream_bufr(
     for count, msg in enumerate(bufr_file, 1):
         # we use a context manager to automatically delete the handle of the BufrMessage.
         # We have to use a wrapper object here because a message can also be a dict
-        with wrap_message(msg) as message:
+        with MessageWrapper.wrap(msg) as message:
             if "count" in value_filters and not value_filters["count"].match(count):
                 continue
 
@@ -732,7 +785,7 @@ def stream_bufr_flat(
     for count, msg in enumerate(bufr_file, 1):
         # we use a context manager to automatically delete the handle of the BufrMessage.
         # We have to use a wrapper object here because a message can also be a dict
-        with wrap_message(msg) as message:
+        with MessageWrapper.wrap(msg) as message:
             # count filter
             if count_filter is not None and not count_filter.match(count):
                 continue

--- a/pdbufr/high_level_bufr/bufr.py
+++ b/pdbufr/high_level_bufr/bufr.py
@@ -17,6 +17,13 @@ from .codesfile import CodesFile
 from .codesmessage import CodesMessage
 
 
+def bufr_code_is_coord(code) -> bool:
+    try:
+        return code <= 9999
+    except:
+        return int(code[:3]) < 10
+
+
 class BufrMessage(CodesMessage):
     __doc__ = "\n".join(CodesMessage.__doc__.splitlines()[4:]).format(
         prod_type="BUFR", classname="BufrMessage", parent="BufrFile", alias="bufr"
@@ -35,8 +42,6 @@ class BufrMessage(CodesMessage):
         """
         super(self.__class__, self).__init__(codes_file, clone, sample, headers_only)
         # self._unpacked = False
-
-        self._is_coord_cache = dict()
 
     # def get(self, key, ktype=None):
     #    """Return requested value, unpacking data values if necessary."""
@@ -92,32 +97,16 @@ class BufrMessage(CodesMessage):
         """Copy data values from this message to another message"""
         return eccodes.codes_bufr_copy_data(self.codes_id, destMsg.codes_id)
 
-    def is_coord(self, key, name=None):
-        if name is None:
-            name = key
-
-        c = self._is_coord_cache.get(name, None)
-        if c is None:
+    def is_coord(self, key):
+        try:
+            c = self._get(key + "->code", int)
             try:
-                c = self._get(name + "->code", int)
-                try:
-                    c = self.code_is_coord(c)
-                    self._is_coord_cache[name] = c
-                    return c
-                except:
-                    return False
+                return bufr_code_is_coord(c)
             except:
                 return False
-        return c
-
-    @staticmethod
-    def code_is_coord(code) -> bool:
-        try:
-            return code <= 9999
         except:
-            return int(code[:3]) < 10
-
-
+            return False
+    
 class BufrFile(CodesFile):
     __doc__ = "\n".join(CodesFile.__doc__.splitlines()[4:]).format(
         prod_type="BUFR", classname="BufrFile", alias="bufr"

--- a/pdbufr/high_level_bufr/bufr.py
+++ b/pdbufr/high_level_bufr/bufr.py
@@ -106,7 +106,8 @@ class BufrMessage(CodesMessage):
                 return False
         except:
             return False
-    
+
+
 class BufrFile(CodesFile):
     __doc__ = "\n".join(CodesFile.__doc__.splitlines()[4:]).format(
         prod_type="BUFR", classname="BufrFile", alias="bufr"

--- a/tests/test_20_bufr_structure.py
+++ b/tests/test_20_bufr_structure.py
@@ -426,7 +426,7 @@ def test_code_is_coord() -> None:
     """Ensures that the different ways of identifying a coordinate key from
     the BUFR descriptor/code agree"""
 
-    from pdbufr.high_level_bufr.bufr import BufrMessage
+    from pdbufr.high_level_bufr.bufr import bufr_code_is_coord
 
     data = {
         "000300": True,
@@ -439,5 +439,5 @@ def test_code_is_coord() -> None:
     }
 
     for k, v in data.items():
-        assert BufrMessage.code_is_coord(k) == v
-        assert BufrMessage.code_is_coord(int(k)) == v
+        assert bufr_code_is_coord(k) == v
+        assert bufr_code_is_coord(int(k)) == v


### PR DESCRIPTION
The aim of this PR is to simplify the code that checks if a BUFR key is a coordinate descriptor. The performance optimisation related to #54 should not be affected.