### PR TITLE
Add build to readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,6 +1,9 @@
 version: 2
 formats: []
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.9"
 python:
-  version: 3.8
   install:
-    - requirements: docs/requirements.txt
+  - requirements: docs/requirements.txt


### PR DESCRIPTION
This is to fix the following read the docs warning:

```
... This config is deprecated in favor of "build.os" and will be removed on October 16, 2023. [Read our blog post to migrate to "build.os"](https://blog.readthedocs.com/use-build-os-config/) and ensure your project continues building successfully.
```