### PR TITLE
Fix tests on pandas 3.0

### DIFF
--- a/tests/readers/flat/test_flat_reader.py
+++ b/tests/readers/flat/test_flat_reader.py
@@ -402,6 +402,7 @@ def test_read_flat_bufr_uncompressed_subsets(_kwargs: dict) -> None:
 
     # compare to csv
     res = pdbufr.read_bufr(TEST_DATA_2, "all", flat=True, filters={"stationNumber": [27, 84]}, **_kwargs)
+    res = res.replace({None: np.nan})
 
     assert isinstance(res, pd.DataFrame)
     assert "edition" in res
@@ -426,7 +427,7 @@ def test_read_flat_bufr_uncompressed_subsets(_kwargs: dict) -> None:
     )
 
     assert res.columns.to_list() == ref.columns.to_list()
-    assert_frame_equal(res.iloc[:, :39], ref.iloc[:, :39])
+    assert_frame_equal(res.iloc[:, :39], ref.iloc[:, :39], check_dtype=False)
 
 
 @pytest.mark.parametrize("_kwargs", [{"prefilter_headers": False}, {"prefilter_headers": True}])

--- a/tests/readers/generic/test_generic_reader.py
+++ b/tests/readers/generic/test_generic_reader.py
@@ -767,10 +767,10 @@ def test_sat_compressed_1() -> None:
     res = pdbufr.read_bufr(TEST_DATA_8, columns=columns, filters={"firstOrderStatistics": 15})
 
     assert len(res) == 128 * 12 * 3
-    assert_frame_equal(res[0:1], ref_1[res.columns])
-    assert_frame_equal(res[1:2], ref_2[res.columns])
-    assert_frame_equal(res[11:12], ref_12[res.columns])
-    assert_frame_equal(res[12:13], ref_13[res.columns])
+    assert_frame_equal(res[0:1], ref_1[res.columns], check_dtype=False)
+    assert_frame_equal(res[1:2], ref_2[res.columns], check_dtype=False)
+    assert_frame_equal(res[11:12], ref_12[res.columns], check_dtype=False)
+    assert_frame_equal(res[12:13], ref_13[res.columns], check_dtype=False)
 
 
 def assert_simple_key_core(path, param, key, key_value, ref, part=False, **kwargs):

--- a/tests/readers/synop/test_synop.py
+++ b/tests/readers/synop/test_synop.py
@@ -38,6 +38,7 @@ def test_synop_reader():
         level_columns=False,
         units_columns=False,
     )
+    df = df.replace({None: np.nan})
 
     # r = df.to_dict()
     # print("r=", r)
@@ -52,8 +53,7 @@ def test_synop_reader():
 
     df_ref = pd.DataFrame.from_dict(DATA.REF)
     df_ref.reset_index(drop=True, inplace=True)
-
-    df = df.replace(np.nan, None)
+    df_ref = df_ref.replace({None: np.nan})
 
     print("df=", df.columns.tolist())
     print("df_ref=", df_ref.columns.tolist())
@@ -720,6 +720,7 @@ def test_synop_radiation(columns, expected_values):
         reader="synop",
         columns=columns,
     )
+    df = df.replace({None: np.nan})
 
     ref_stations = [
         {
@@ -742,11 +743,15 @@ def test_synop_radiation(columns, expected_values):
 
     df_ref = pd.DataFrame.from_dict(ref)
     df_ref.reset_index(drop=True, inplace=True)
-    df = df.replace(np.nan, None)
+    df_ref = df_ref.replace({None: np.nan})
 
     try:
         pd.testing.assert_frame_equal(
-            df, df_ref, check_dtype=False, check_index_type=False, check_datetimelike_compat=True
+            df,
+            df_ref,
+            check_dtype=False,
+            check_index_type=False,
+            check_datetimelike_compat=True,
         )
     except Exception as e:
         print("e=", e)

--- a/tests/readers/temp/test_temp.py
+++ b/tests/readers/temp/test_temp.py
@@ -31,7 +31,10 @@ DATA = _get_data()
 
 
 def test_temp_reader():
-    df = pdbufr.read_bufr(TEST_DATA_CLASSIC, reader="temp", filters={"count": 1})
+    df = pdbufr.read_bufr(
+        TEST_DATA_CLASSIC, reader="temp", filters={"count": 1}
+    )
+    df = df.replace({None: np.nan})
 
     # r = df.to_dict()
     # print("r=", r)
@@ -48,7 +51,6 @@ def test_temp_reader():
 
     df_ref = pd.DataFrame.from_dict(DATA.REF)
     df_ref.reset_index(drop=True, inplace=True)
-    df = df.replace(np.nan, None)
 
     # print("df=", df.columns.tolist())
     # print("df_ref=", df_ref.columns.tolist())


### PR DESCRIPTION
### Description
Some tests were failing with pandas 3.0, all related to nan vs None.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 